### PR TITLE
fix wall restraints in acd yaml files

### DIFF
--- a/taproom/systems/acd/bam/guest.yaml
+++ b/taproom/systems/acd/bam/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/but/guest.yaml
+++ b/taproom/systems/acd/but/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/cbu/guest.yaml
+++ b/taproom/systems/acd/cbu/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/chp/guest.yaml
+++ b/taproom/systems/acd/chp/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/coc/guest.yaml
+++ b/taproom/systems/acd/coc/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/cpe/guest.yaml
+++ b/taproom/systems/acd/cpe/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/ham/guest.yaml
+++ b/taproom/systems/acd/ham/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/hep/guest.yaml
+++ b/taproom/systems/acd/hep/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/hex/guest.yaml
+++ b/taproom/systems/acd/hex/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/hp6/guest.yaml
+++ b/taproom/systems/acd/hp6/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/hpa/guest.yaml
+++ b/taproom/systems/acd/hpa/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/hx2/guest.yaml
+++ b/taproom/systems/acd/hx2/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/hx3/guest.yaml
+++ b/taproom/systems/acd/hx3/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/mba/guest.yaml
+++ b/taproom/systems/acd/mba/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/mha/guest.yaml
+++ b/taproom/systems/acd/mha/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/mhp/guest.yaml
+++ b/taproom/systems/acd/mhp/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/nmb/guest.yaml
+++ b/taproom/systems/acd/nmb/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/nmh/guest.yaml
+++ b/taproom/systems/acd/nmh/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/oam/guest.yaml
+++ b/taproom/systems/acd/oam/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/oct/guest.yaml
+++ b/taproom/systems/acd/oct/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/pam/guest.yaml
+++ b/taproom/systems/acd/pam/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 

--- a/taproom/systems/acd/pnt/guest.yaml
+++ b/taproom/systems/acd/pnt/guest.yaml
@@ -65,10 +65,6 @@ restraints:
         force_constant: 50.0
         target: 12.5
     - restraint:
-        atoms: ":7@C1 G1"
-        force_constant: 50.0
-        target: 12.5
-    - restraint:
         atoms: ":1@O1 G1"
         force_constant: 50.0
         target: 14.5
@@ -90,10 +86,6 @@ restraints:
         target: 14.5
     - restraint:
         atoms: ":6@O1 G1"
-        force_constant: 50.0
-        target: 14.5
-    - restraint:
-        atoms: ":7@O1 G1"
         force_constant: 50.0
         target: 14.5
 


### PR DESCRIPTION
removed wall restraint with a 7th monomer in the acd host-guest sytems