### PR TITLE
fix host static dihedral restraint

### DIFF
--- a/taproom/systems/acd/host-p.yaml
+++ b/taproom/systems/acd/host-p.yaml
@@ -24,7 +24,7 @@ restraints:
         atoms: D1 H1 H2
         force_constant: 100.0
     - restraint:
-        atoms: D2 D1 H2 H3
+        atoms: D2 D1 H1 H2
         force_constant: 100.0
     - restraint:
         atoms: D1 H1 H2 H3

--- a/taproom/systems/acd/host-s.yaml
+++ b/taproom/systems/acd/host-s.yaml
@@ -24,7 +24,7 @@ restraints:
         atoms: D1 H1 H2
         force_constant: 100.0
     - restraint:
-        atoms: D2 D1 H2 H3
+        atoms: D2 D1 H1 H2
         force_constant: 100.0
     - restraint:
         atoms: D1 H1 H2 H3

--- a/taproom/systems/bcd/host-p.yaml
+++ b/taproom/systems/bcd/host-p.yaml
@@ -24,7 +24,7 @@ restraints:
         atoms: D1 H1 H2
         force_constant: 100.0
     - restraint:
-        atoms: D2 D1 H2 H3
+        atoms: D2 D1 H1 H2
         force_constant: 100.0
     - restraint:
         atoms: D1 H1 H2 H3

--- a/taproom/systems/bcd/host-s.yaml
+++ b/taproom/systems/bcd/host-s.yaml
@@ -24,7 +24,7 @@ restraints:
         atoms: D1 H1 H2
         force_constant: 100.0
     - restraint:
-        atoms: D2 D1 H2 H3
+        atoms: D2 D1 H1 H2
         force_constant: 100.0
     - restraint:
         atoms: D1 H1 H2 H3


### PR DESCRIPTION
Minor bugfix: 

- Change dihedral restraint for host-*.yaml - D2 D1 H2 H3 --> D2 D1 H1 H2

Reason:

- The original definition can cause problems in implicit solvent simulations.