### PR TITLE
Update definition of wall and symmetry restraints

### DIFF
--- a/taproom/systems/acd/bam/guest.yaml
+++ b/taproom/systems/acd/bam/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/bam/guest.yaml
+++ b/taproom/systems/acd/bam/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/but/guest.yaml
+++ b/taproom/systems/acd/but/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/but/guest.yaml
+++ b/taproom/systems/acd/but/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/cbu/guest.yaml
+++ b/taproom/systems/acd/cbu/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/cbu/guest.yaml
+++ b/taproom/systems/acd/cbu/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/chp/guest.yaml
+++ b/taproom/systems/acd/chp/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/chp/guest.yaml
+++ b/taproom/systems/acd/chp/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/coc/guest.yaml
+++ b/taproom/systems/acd/coc/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/coc/guest.yaml
+++ b/taproom/systems/acd/coc/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/cpe/guest.yaml
+++ b/taproom/systems/acd/cpe/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/cpe/guest.yaml
+++ b/taproom/systems/acd/cpe/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/ham/guest.yaml
+++ b/taproom/systems/acd/ham/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/ham/guest.yaml
+++ b/taproom/systems/acd/ham/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/hep/guest.yaml
+++ b/taproom/systems/acd/hep/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/hep/guest.yaml
+++ b/taproom/systems/acd/hep/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/hex/guest.yaml
+++ b/taproom/systems/acd/hex/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/hex/guest.yaml
+++ b/taproom/systems/acd/hex/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/hp6/guest.yaml
+++ b/taproom/systems/acd/hp6/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/hp6/guest.yaml
+++ b/taproom/systems/acd/hp6/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/hpa/guest.yaml
+++ b/taproom/systems/acd/hpa/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/hpa/guest.yaml
+++ b/taproom/systems/acd/hpa/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/hx2/guest.yaml
+++ b/taproom/systems/acd/hx2/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/hx2/guest.yaml
+++ b/taproom/systems/acd/hx2/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/hx3/guest.yaml
+++ b/taproom/systems/acd/hx3/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/hx3/guest.yaml
+++ b/taproom/systems/acd/hx3/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/mba/guest.yaml
+++ b/taproom/systems/acd/mba/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/mba/guest.yaml
+++ b/taproom/systems/acd/mba/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/mha/guest.yaml
+++ b/taproom/systems/acd/mha/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/mha/guest.yaml
+++ b/taproom/systems/acd/mha/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/mhp/guest.yaml
+++ b/taproom/systems/acd/mhp/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/mhp/guest.yaml
+++ b/taproom/systems/acd/mhp/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/nmb/guest.yaml
+++ b/taproom/systems/acd/nmb/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/nmb/guest.yaml
+++ b/taproom/systems/acd/nmb/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/nmh/guest.yaml
+++ b/taproom/systems/acd/nmh/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/nmh/guest.yaml
+++ b/taproom/systems/acd/nmh/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/oam/guest.yaml
+++ b/taproom/systems/acd/oam/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/oam/guest.yaml
+++ b/taproom/systems/acd/oam/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/oct/guest.yaml
+++ b/taproom/systems/acd/oct/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/oct/guest.yaml
+++ b/taproom/systems/acd/oct/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/pam/guest.yaml
+++ b/taproom/systems/acd/pam/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/pam/guest.yaml
+++ b/taproom/systems/acd/pam/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/acd/pnt/guest.yaml
+++ b/taproom/systems/acd/pnt/guest.yaml
@@ -92,7 +92,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/acd/pnt/guest.yaml
+++ b/taproom/systems/acd/pnt/guest.yaml
@@ -43,51 +43,51 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 11.3
+        target: 9.3
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 13.3
+        target: 11.3
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/ben/guest.yaml
+++ b/taproom/systems/bcd/ben/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/ben/guest.yaml
+++ b/taproom/systems/bcd/ben/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/cbu/guest.yaml
+++ b/taproom/systems/bcd/cbu/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/cbu/guest.yaml
+++ b/taproom/systems/bcd/cbu/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/chp/guest.yaml
+++ b/taproom/systems/bcd/chp/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/chp/guest.yaml
+++ b/taproom/systems/bcd/chp/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/coc/guest.yaml
+++ b/taproom/systems/bcd/coc/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/coc/guest.yaml
+++ b/taproom/systems/bcd/coc/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/cpe/guest.yaml
+++ b/taproom/systems/bcd/cpe/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/cpe/guest.yaml
+++ b/taproom/systems/bcd/cpe/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/ham/guest.yaml
+++ b/taproom/systems/bcd/ham/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/ham/guest.yaml
+++ b/taproom/systems/bcd/ham/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/hep/guest.yaml
+++ b/taproom/systems/bcd/hep/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/hep/guest.yaml
+++ b/taproom/systems/bcd/hep/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/hex/guest.yaml
+++ b/taproom/systems/bcd/hex/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/hex/guest.yaml
+++ b/taproom/systems/bcd/hex/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/m4c/guest.yaml
+++ b/taproom/systems/bcd/m4c/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/m4c/guest.yaml
+++ b/taproom/systems/bcd/m4c/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/m4t/guest.yaml
+++ b/taproom/systems/bcd/m4t/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/m4t/guest.yaml
+++ b/taproom/systems/bcd/m4t/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/mch/guest.yaml
+++ b/taproom/systems/bcd/mch/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/mch/guest.yaml
+++ b/taproom/systems/bcd/mch/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/mha/guest.yaml
+++ b/taproom/systems/bcd/mha/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/mha/guest.yaml
+++ b/taproom/systems/bcd/mha/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/mo3/guest.yaml
+++ b/taproom/systems/bcd/mo3/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/mo3/guest.yaml
+++ b/taproom/systems/bcd/mo3/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/mo4/guest.yaml
+++ b/taproom/systems/bcd/mo4/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/mo4/guest.yaml
+++ b/taproom/systems/bcd/mo4/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/mp3/guest.yaml
+++ b/taproom/systems/bcd/mp3/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/mp3/guest.yaml
+++ b/taproom/systems/bcd/mp3/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/mp4/guest.yaml
+++ b/taproom/systems/bcd/mp4/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/mp4/guest.yaml
+++ b/taproom/systems/bcd/mp4/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/oam/guest.yaml
+++ b/taproom/systems/bcd/oam/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/oam/guest.yaml
+++ b/taproom/systems/bcd/oam/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/pb3/guest.yaml
+++ b/taproom/systems/bcd/pb3/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/pb3/guest.yaml
+++ b/taproom/systems/bcd/pb3/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/pb4/guest.yaml
+++ b/taproom/systems/bcd/pb4/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/pb4/guest.yaml
+++ b/taproom/systems/bcd/pb4/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/pha/guest.yaml
+++ b/taproom/systems/bcd/pha/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/pha/guest.yaml
+++ b/taproom/systems/bcd/pha/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:

--- a/taproom/systems/bcd/pnt/guest.yaml
+++ b/taproom/systems/bcd/pnt/guest.yaml
@@ -100,7 +100,7 @@ restraints:
 symmetry_correction:
   restraints:
       - restraint:
-        atoms: D1 G1 G2
+        atoms: D2 G1 G2
         force_constant: 200.0
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then

--- a/taproom/systems/bcd/pnt/guest.yaml
+++ b/taproom/systems/bcd/pnt/guest.yaml
@@ -43,59 +43,59 @@ restraints:
     - restraint:
         atoms: ":1@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":2@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":3@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":4@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":5@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":6@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":7@O2 G1"
         force_constant: 50.0
-        target: 12.5
+        target: 10.5
     - restraint:
         atoms: ":1@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":2@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":3@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":4@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":5@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":6@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
     - restraint:
         atoms: ":7@O6 G1"
         force_constant: 50.0
-        target: 14.5
+        target: 12.5
 
 symmetry_correction:
   restraints:


### PR DESCRIPTION
Shorten the distance for wall restraints and change the anchor atoms for symmetry restraint from `D1-G1-G2` to `D2-G1-G2`.