### PR TITLE
Add cyclodextrin monomer MOL2 file to host yaml file

### DIFF
--- a/taproom/systems/acd/cpe/measurement.yaml
+++ b/taproom/systems/acd/cpe/measurement.yaml
@@ -4,7 +4,7 @@ state:
   pH: 6.90
 
 substance:
-  name: cyclopentaol
+  name: cyclopentanol
   SMILES: "C1CCC(C1)O"
   buffer:
     - "[Na+].OP(O)([O-])=O": 0.025 mol kg-1

--- a/taproom/systems/acd/host-p.yaml
+++ b/taproom/systems/acd/host-p.yaml
@@ -1,5 +1,6 @@
 name: acd
 structure: acd.mol2
+monomer: MGO.mol2
 net_charge: 0
 resname: MGO
 aliases:

--- a/taproom/systems/acd/host-s.yaml
+++ b/taproom/systems/acd/host-s.yaml
@@ -1,5 +1,6 @@
 name: acd
 structure: acd.mol2
+monomer: MGO.mol2
 net_charge: 0
 resname: MGO
 aliases:

--- a/taproom/systems/bcd/host-p.yaml
+++ b/taproom/systems/bcd/host-p.yaml
@@ -1,5 +1,6 @@
 name: bcd
 structure: bcd.mol2
+monomer: MGO.mol2
 resname: MGO
 net_charge: 0
 aliases:

--- a/taproom/systems/bcd/host-s.yaml
+++ b/taproom/systems/bcd/host-s.yaml
@@ -1,5 +1,6 @@
 name: bcd
 structure: bcd.mol2
+monomer: MGO.mol2
 net_charge: 0
 resname: MGO
 aliases:


### PR DESCRIPTION
* File names of `MGO.mol2` are stored in the `host-*.yaml` files since we need this for generating Amber files with TLeap.
* fix molecule name for cyclopentanol in `measurement.yaml`.