### PR TITLE
Add OpenFF units to values in YAML files

### DIFF
--- a/taproom/systems/acd/bam/guest.yaml
+++ b/taproom/systems/acd/bam/guest.yaml
@@ -1,7 +1,7 @@
 name: bam
 structure: bam.mol2
 complex: a-bam.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/but/guest.yaml
+++ b/taproom/systems/acd/but/guest.yaml
@@ -1,7 +1,7 @@
 name: but
 structure: but.mol2
 complex: a-but.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/cbu/guest.yaml
+++ b/taproom/systems/acd/cbu/guest.yaml
@@ -1,7 +1,7 @@
 name: cbu
 structure: cbu.mol2
 complex: a-cbu.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/chp/guest.yaml
+++ b/taproom/systems/acd/chp/guest.yaml
@@ -1,7 +1,7 @@
 name: chp
 structure: chp.mol2
 complex: a-chp.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/coc/guest.yaml
+++ b/taproom/systems/acd/coc/guest.yaml
@@ -1,7 +1,7 @@
 name: coc
 structure: coc.mol2
 complex: a-coc.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/cpe/guest.yaml
+++ b/taproom/systems/acd/cpe/guest.yaml
@@ -1,7 +1,7 @@
 name: cpe
 structure: cpe.mol2
 complex: a-cpe.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/ham/guest.yaml
+++ b/taproom/systems/acd/ham/guest.yaml
@@ -1,7 +1,7 @@
 name: ham
 structure: ham.mol2
 complex: a-ham.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/hep/guest.yaml
+++ b/taproom/systems/acd/hep/guest.yaml
@@ -1,7 +1,7 @@
 name: hep
 structure: hep.mol2
 complex: a-hep.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/hex/guest.yaml
+++ b/taproom/systems/acd/hex/guest.yaml
@@ -1,7 +1,7 @@
 name: hex
 structure: hex.mol2
 complex: a-hex.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/host-p.yaml
+++ b/taproom/systems/acd/host-p.yaml
@@ -1,7 +1,7 @@
 name: acd
 structure: acd.mol2
 monomer: MGO.mol2
-net_charge: 0
+net_charge: 0e
 resname: MGO
 aliases:
   - D1: ":DM1"
@@ -14,71 +14,71 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":1@O5 :1@C1 :1@O1 :2@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":2@O5 :2@C1 :2@O1 :3@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":3@O5 :3@C1 :3@O1 :4@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":4@O5 :4@C1 :4@O1 :5@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":5@O5 :5@C1 :5@O1 :6@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":6@O5 :6@C1 :6@O1 :1@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":1@C1 :1@O1 :2@C4 :2@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":2@C1 :2@O1 :3@C4 :3@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":3@C1 :3@O1 :4@C4 :4@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":4@C1 :4@O1 :5@C4 :5@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":5@C1 :5@O1 :6@C4 :6@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":6@C1 :6@O1 :1@C4 :1@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
 calculation:
   windows:
     attach: 15
@@ -88,7 +88,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 2000
     model: "TIP3P"

--- a/taproom/systems/acd/host-s.yaml
+++ b/taproom/systems/acd/host-s.yaml
@@ -1,7 +1,7 @@
 name: acd
 structure: acd.mol2
 monomer: MGO.mol2
-net_charge: 0
+net_charge: 0e
 resname: MGO
 aliases:
   - D1: ":DM1"
@@ -14,71 +14,71 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":1@O5 :1@C1 :1@O1 :2@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":2@O5 :2@C1 :2@O1 :3@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":3@O5 :3@C1 :3@O1 :4@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":4@O5 :4@C1 :4@O1 :5@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":5@O5 :5@C1 :5@O1 :6@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":6@O5 :6@C1 :6@O1 :1@C4"
-        force_constant: 6.0
-        target: 104.3
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 104.3 * degrees
     - restraint:
         atoms: ":1@C1 :1@O1 :2@C4 :2@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":2@C1 :2@O1 :3@C4 :3@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":3@C1 :3@O1 :4@C4 :4@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":4@C1 :4@O1 :5@C4 :5@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":5@C1 :5@O1 :6@C4 :6@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
     - restraint:
         atoms: ":6@C1 :6@O1 :1@C4 :1@C5"
-        force_constant: 6.0
-        target: -108.8
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -108.8 * degrees
 calculation:
   windows:
     attach: 15
@@ -88,7 +88,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 2000
     model: "TIP3P"

--- a/taproom/systems/acd/hp6/guest.yaml
+++ b/taproom/systems/acd/hp6/guest.yaml
@@ -1,7 +1,7 @@
 name: hp6
 structure: hp6.mol2
 complex: a-hp6.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/hpa/guest.yaml
+++ b/taproom/systems/acd/hpa/guest.yaml
@@ -1,7 +1,7 @@
 name: hpa
 structure: hpa.mol2
 complex: a-hpa.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/hx2/guest.yaml
+++ b/taproom/systems/acd/hx2/guest.yaml
@@ -1,7 +1,7 @@
 name: hx2
 structure: hx2.mol2
 complex: a-hx2.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/hx3/guest.yaml
+++ b/taproom/systems/acd/hx3/guest.yaml
@@ -1,7 +1,7 @@
 name: hx3
 structure: hx3.mol2
 complex: a-hx3.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/mba/guest.yaml
+++ b/taproom/systems/acd/mba/guest.yaml
@@ -1,7 +1,7 @@
 name: mba
 structure: mba.mol2
 complex: a-mba.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/mha/guest.yaml
+++ b/taproom/systems/acd/mha/guest.yaml
@@ -1,7 +1,7 @@
 name: mha
 structure: mha.mol2
 complex: a-mha.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/mhp/guest.yaml
+++ b/taproom/systems/acd/mhp/guest.yaml
@@ -1,7 +1,7 @@
 name: mhp
 structure: mhp.mol2
 complex: a-mhp.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/nmb/guest.yaml
+++ b/taproom/systems/acd/nmb/guest.yaml
@@ -1,7 +1,7 @@
 name: nmb
 structure: nmb.mol2
 complex: a-nmb.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/nmh/guest.yaml
+++ b/taproom/systems/acd/nmh/guest.yaml
@@ -1,7 +1,7 @@
 name: nmh
 structure: nmh.mol2
 complex: a-nmh.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/oam/guest.yaml
+++ b/taproom/systems/acd/oam/guest.yaml
@@ -1,7 +1,7 @@
 name: oam
 structure: oam.mol2
 complex: a-oam.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/oct/guest.yaml
+++ b/taproom/systems/acd/oct/guest.yaml
@@ -1,7 +1,7 @@
 name: oct
 structure: oct.mol2
 complex: a-oct.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/pam/guest.yaml
+++ b/taproom/systems/acd/pam/guest.yaml
@@ -1,7 +1,7 @@
 name: pam
 structure: pam.mol2
 complex: a-pam.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/acd/pnt/guest.yaml
+++ b/taproom/systems/acd/pnt/guest.yaml
@@ -1,7 +1,7 @@
 name: pnt
 structure: pnt.mol2
 complex: a-pnt.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,87 +13,88 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radians**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 9.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 9.3 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
         target: 11.3
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 11.3
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 11.3 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/ben/guest.yaml
+++ b/taproom/systems/bcd/ben/guest.yaml
@@ -1,7 +1,7 @@
 name: ben
 structure: ben.mol2
 complex: b-ben.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/cbu/guest.yaml
+++ b/taproom/systems/bcd/cbu/guest.yaml
@@ -1,7 +1,7 @@
 name: cbu
 structure: cbu.mol2
 complex: b-cbu.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/chp/guest.yaml
+++ b/taproom/systems/bcd/chp/guest.yaml
@@ -1,7 +1,7 @@
 name: chp
 structure: chp.mol2
 complex: b-chp.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/coc/guest.yaml
+++ b/taproom/systems/bcd/coc/guest.yaml
@@ -1,7 +1,7 @@
 name: coc
 structure: coc.mol2
 complex: b-coc.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/cpe/guest.yaml
+++ b/taproom/systems/bcd/cpe/guest.yaml
@@ -1,7 +1,7 @@
 name: cpe
 structure: cpe.mol2
 complex: b-cpe.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/ham/guest.yaml
+++ b/taproom/systems/bcd/ham/guest.yaml
@@ -1,7 +1,7 @@
 name: ham
 structure: ham.mol2
 complex: b-ham.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/hep/guest.yaml
+++ b/taproom/systems/bcd/hep/guest.yaml
@@ -1,7 +1,7 @@
 name: hep
 structure: hep.mol2
 complex: b-hep.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/hex/guest.yaml
+++ b/taproom/systems/bcd/hex/guest.yaml
@@ -1,7 +1,7 @@
 name: hex
 structure: hex.mol2
 complex: b-hex.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/host-p.yaml
+++ b/taproom/systems/bcd/host-p.yaml
@@ -2,7 +2,7 @@ name: bcd
 structure: bcd.mol2
 monomer: MGO.mol2
 resname: MGO
-net_charge: 0
+net_charge: 0e
 aliases:
   - D1: ":DM1"
   - D2: ":DM2"
@@ -14,79 +14,79 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":1@O5 :1@C1 :1@O1 :2@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":2@O5 :2@C1 :2@O1 :3@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":3@O5 :3@C1 :3@O1 :4@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":4@O5 :4@C1 :4@O1 :5@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":5@O5 :5@C1 :5@O1 :6@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":6@O5 :6@C1 :6@O1 :7@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":7@O5 :7@C1 :7@O1 :1@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":1@C1 :1@O1 :2@C4 :2@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":2@C1 :2@O1 :3@C4 :3@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":3@C1 :3@O1 :4@C4 :4@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":4@C1 :4@O1 :5@C4 :5@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":5@C1 :5@O1 :6@C4 :6@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":6@C1 :6@O1 :7@C4 :7@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":7@C1 :7@O1 :1@C4 :1@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
 calculation:
   windows:
     attach: 15
@@ -96,7 +96,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 2210
     model: "TIP3P"

--- a/taproom/systems/bcd/host-s.yaml
+++ b/taproom/systems/bcd/host-s.yaml
@@ -1,7 +1,7 @@
 name: bcd
 structure: bcd.mol2
 monomer: MGO.mol2
-net_charge: 0
+net_charge: 0e
 resname: MGO
 aliases:
   - D1: ":DM1"
@@ -14,79 +14,79 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":1@O5 :1@C1 :1@O1 :2@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":2@O5 :2@C1 :2@O1 :3@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":3@O5 :3@C1 :3@O1 :4@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":4@O5 :4@C1 :4@O1 :5@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":5@O5 :5@C1 :5@O1 :6@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":6@O5 :6@C1 :6@O1 :7@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":7@O5 :7@C1 :7@O1 :1@C4"
-        force_constant: 6.0
-        target: 108.7
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: 108.7 * degrees
     - restraint:
         atoms: ":1@C1 :1@O1 :2@C4 :2@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":2@C1 :2@O1 :3@C4 :3@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":3@C1 :3@O1 :4@C4 :4@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":4@C1 :4@O1 :5@C4 :5@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":5@C1 :5@O1 :6@C4 :6@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":6@C1 :6@O1 :7@C4 :7@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
     - restraint:
         atoms: ":7@C1 :7@O1 :1@C4 :1@C5"
-        force_constant: 6.0
-        target: -112.5
+        force_constant: 6.0 * kilocalorie / mole / radian**2
+        target: -112.5 * degrees
 calculation:
   windows:
     attach: 15
@@ -96,7 +96,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 2210
     model: "TIP3P"

--- a/taproom/systems/bcd/m4c/guest.yaml
+++ b/taproom/systems/bcd/m4c/guest.yaml
@@ -1,7 +1,7 @@
 name: m4c
 structure: m4c.mol2
 complex: b-m4c.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/m4t/guest.yaml
+++ b/taproom/systems/bcd/m4t/guest.yaml
@@ -1,7 +1,7 @@
 name: m4t
 structure: m4t.mol2
 complex: b-m4t.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/mch/guest.yaml
+++ b/taproom/systems/bcd/mch/guest.yaml
@@ -1,7 +1,7 @@
 name: mch
 structure: mch.mol2
 complex: b-mch.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/mha/guest.yaml
+++ b/taproom/systems/bcd/mha/guest.yaml
@@ -1,7 +1,7 @@
 name: mha
 structure: mha.mol2
 complex: b-mha.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/mo3/guest.yaml
+++ b/taproom/systems/bcd/mo3/guest.yaml
@@ -1,7 +1,7 @@
 name: mo3
 structure: mo3.mol2
 complex: b-mo3.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/mo4/guest.yaml
+++ b/taproom/systems/bcd/mo4/guest.yaml
@@ -1,7 +1,7 @@
 name: mo4
 structure: mo4.mol2
 complex: b-mo4.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/mp3/guest.yaml
+++ b/taproom/systems/bcd/mp3/guest.yaml
@@ -1,7 +1,7 @@
 name: mp3
 structure: mp3.mol2
 complex: b-mp3.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/mp4/guest.yaml
+++ b/taproom/systems/bcd/mp4/guest.yaml
@@ -1,7 +1,7 @@
 name: mp4
 structure: mp4.mol2
 complex: b-mp4.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/oam/guest.yaml
+++ b/taproom/systems/bcd/oam/guest.yaml
@@ -1,7 +1,7 @@
 name: oam
 structure: oam.mol2
 complex: b-oam.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/pb3/guest.yaml
+++ b/taproom/systems/bcd/pb3/guest.yaml
@@ -1,7 +1,7 @@
 name: pb3
 structure: pb3.mol2
 complex: b-pb3.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/pb4/guest.yaml
+++ b/taproom/systems/bcd/pb4/guest.yaml
@@ -1,7 +1,7 @@
 name: pb4
 structure: pb4.mol2
 complex: b-pb4.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/pha/guest.yaml
+++ b/taproom/systems/bcd/pha/guest.yaml
@@ -1,7 +1,7 @@
 name: pha
 structure: pha.mol2
 complex: b-pha.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/pnt/guest.yaml
+++ b/taproom/systems/bcd/pnt/guest.yaml
@@ -1,7 +1,7 @@
 name: pnt
 structure: pnt.mol2
 complex: b-pnt.pdb
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/bcd/rim/guest.yaml
+++ b/taproom/systems/bcd/rim/guest.yaml
@@ -1,7 +1,7 @@
 name: rim
 structure: rim.mol2
 complex: b-rim.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":1@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":2@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":3@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":4@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":5@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":6@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":7@O2 G1"
-        force_constant: 50.0
-        target: 10.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 10.5 * angstrom
     - restraint:
         atoms: ":1@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":2@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":3@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":4@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":5@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":6@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
     - restraint:
         atoms: ":7@O6 G1"
-        force_constant: 50.0
-        target: 12.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 12.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/ad2/guest.yaml
+++ b/taproom/systems/cb7/ad2/guest.yaml
@@ -1,7 +1,7 @@
 name: ad2
 structure: ad2.mol2
 complex: cb7-ad2.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/adh/guest.yaml
+++ b/taproom/systems/cb7/adh/guest.yaml
@@ -1,7 +1,7 @@
 name: adh
 structure: adh.mol2
 complex: cb7-adh.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/adn/guest.yaml
+++ b/taproom/systems/cb7/adn/guest.yaml
@@ -1,7 +1,7 @@
 name: adn
 structure: adn.mol2
 complex: cb7-adn.pdb
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/adz/guest.yaml
+++ b/taproom/systems/cb7/adz/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-adz.pdb
 data_set:
   SAMPL: 4
   guest_id: C13
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/axm/guest.yaml
+++ b/taproom/systems/cb7/axm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-axm.pdb
 data_set:
   SAMPL: 4
   guest_id: C4
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/b02/guest.yaml
+++ b/taproom/systems/cb7/b02/guest.yaml
@@ -1,7 +1,7 @@
 name: b02
 structure: b02.mol2
 complex: cb7-b02.pdb
-net_charge: 0
+net_charge: 0e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/b05/guest.yaml
+++ b/taproom/systems/cb7/b05/guest.yaml
@@ -1,7 +1,7 @@
 name: b05
 structure: b05.mol2
 complex: cb7-b05.pdb
-net_charge: +2
+net_charge: +2e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/b11/guest.yaml
+++ b/taproom/systems/cb7/b11/guest.yaml
@@ -1,7 +1,7 @@
 name: b11
 structure: b11.mol2
 complex: cb7-b11.pdb
-net_charge: +4
+net_charge: +4e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/bhm/guest.yaml
+++ b/taproom/systems/cb7/bhm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-bhm.pdb
 data_set:
   SAMPL: 4
   guest_id: C11
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/c6m/guest.yaml
+++ b/taproom/systems/cb7/c6m/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-c6m.pdb
 data_set:
   SAMPL: 4
   guest_id: C7
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/c7m/guest.yaml
+++ b/taproom/systems/cb7/c7m/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-c7m.pdb
 data_set:
   SAMPL: 4
   guest_id: C8
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/c8m/guest.yaml
+++ b/taproom/systems/cb7/c8m/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-c8m.pdb
 data_set:
   SAMPL: 4
   guest_id: C9
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/cha/guest.yaml
+++ b/taproom/systems/cb7/cha/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-cha.pdb
 data_set:
   SAMPL: 4
   guest_id: C5
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/chm/guest.yaml
+++ b/taproom/systems/cb7/chm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-chm.pdb
 data_set:
   SAMPL: 4
   guest_id: C6
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/dpm/guest.yaml
+++ b/taproom/systems/cb7/dpm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-dpm.pdb
 data_set:
   SAMPL: 4
   guest_id: C2
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/haz/guest.yaml
+++ b/taproom/systems/cb7/haz/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-haz.pdb
 data_set:
   SAMPL: 4
   guest_id: C14
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/host-p.yaml
+++ b/taproom/systems/cb7/host-p.yaml
@@ -1,7 +1,7 @@
 name: cb7
 structure: cb7.mol2
 resname: CB7
-net_charge: 0
+net_charge: 0e
 aliases:
   - D1: ":DM1"
   - D2: ":DM2"
@@ -13,79 +13,79 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":CB7@N1 :CB7@N8"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N2 :CB7@N9"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N3 :CB7@N10"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N4 :CB7@N11"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N5 :CB7@N12"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N6 :CB7@N13"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N7 :CB7@N14"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N15 :CB7@N22"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N16 :CB7@N23"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N17 :CB7@N24"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N18 :CB7@N25"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N19 :CB7@N26"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N20 :CB7@N27"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@N21 :CB7@N28"
-        force_constant: 15.0
-        target: 13.5
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 calculation:
   windows:
     attach: 15
@@ -95,7 +95,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 2200
     model: "TIP3P"

--- a/taproom/systems/cb7/hpm/guest.yaml
+++ b/taproom/systems/cb7/hpm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-hpm.pdb
 data_set:
   SAMPL: 4
   guest_id: C12
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/hxm/guest.yaml
+++ b/taproom/systems/cb7/hxm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-hxm.pdb
 data_set:
   SAMPL: 4
   guest_id: C3
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/mvn/guest.yaml
+++ b/taproom/systems/cb7/mvn/guest.yaml
@@ -1,7 +1,7 @@
 name: mvn
 structure: mvn.mol2
 complex: cb7-mvn.pdb
-net_charge: +2
+net_charge: +2e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -13,95 +13,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/phm/guest.yaml
+++ b/taproom/systems/cb7/phm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-phm.pdb
 data_set:
   SAMPL: 4
   guest_id: C1
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/prm/guest.yaml
+++ b/taproom/systems/cb7/prm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb7-prm.pdb
 data_set:
   SAMPL: 4
   guest_id: C10
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
-        atoms: ":CB7@25 G1"
-        force_constant: 50.0
-        target: 15.0
+        atoms: ":CB7@C25 G1"
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/tbz/guest.yaml
+++ b/taproom/systems/cb7/tbz/guest.yaml
@@ -1,7 +1,7 @@
 name: tbz
 structure: tbz.mol2
 complex: cb7-tbz.pdb
-net_charge: +2
+net_charge: +2e
 data_set:
   SAMPL: 3
   guest_id: G8
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb7/tdz/guest.yaml
+++ b/taproom/systems/cb7/tdz/guest.yaml
@@ -1,7 +1,7 @@
 name: tdz
 structure: tdz.mol2
 complex: cb7-tdz.pdb
-net_charge: +2
+net_charge: +2e
 data_set:
   SAMPL: 3
   guest_id: G9
@@ -16,95 +16,96 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB7@C15 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C17 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C19 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C20 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C22 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C23 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C25 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C26 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C28 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C29 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C31 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C32 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C34 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":CB7@C35 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/amm/guest.yaml
+++ b/taproom/systems/cb8/amm/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-amm.pdb
 data_set:
   SAMPL: 6
   guest_id: G10
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/con/guest.yaml
+++ b/taproom/systems/cb8/con/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-con.pdb
 data_set:
   SAMPL: 8
   guest_id: G7
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/dan/guest.yaml
+++ b/taproom/systems/cb8/dan/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-dan.pdb
 data_set:
   SAMPL: 6
   guest_id: G8
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/dpz/guest.yaml
+++ b/taproom/systems/cb8/dpz/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-dpz.pdb
 data_set:
   SAMPL: 6
   guest_id: G11
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/esc/guest.yaml
+++ b/taproom/systems/cb8/esc/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-esc.pdb
 data_set:
   SAMPL: 6
   guest_id: G0
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/fen/guest.yaml
+++ b/taproom/systems/cb8/fen/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-fen.pdb
 data_set:
   SAMPL: 8
   guest_id: G2
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/gtr/guest.yaml
+++ b/taproom/systems/cb8/gtr/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-gtr.pdb
 data_set:
   SAMPL: 6
   guest_id: G4
-net_charge: +3
+net_charge: +3e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/han/guest.yaml
+++ b/taproom/systems/cb8/han/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-han.pdb
 data_set:
   SAMPL: 6
   guest_id: G6
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/hmo/guest.yaml
+++ b/taproom/systems/cb8/hmo/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-hmo.pdb
 data_set:
   SAMPL: 8
   guest_id: G4
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/host-p.yaml
+++ b/taproom/systems/cb8/host-p.yaml
@@ -1,7 +1,7 @@
 name: cb8
 structure: cb8.mol2
 resname: CB8
-net_charge: 0
+net_charge: 0e
 aliases:
   - D1: ":DM1"
   - D2: ":DM2"
@@ -13,87 +13,87 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":CB8@N1 :CB8@N9"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N2 :CB8@N10"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N3 :CB8@N11"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N4 :CB8@N12"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N5 :CB8@N13"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N6 :CB8@N14"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N7 :CB8@N15"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N8 :CB8@N16"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N17 :CB8@N25"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N18 :CB8@N26"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N19 :CB8@N27"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N20 :CB8@N28"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N21 :CB8@N29"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N22 :CB8@N30"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N23 :CB8@N31"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@N24 :CB8@N32"
-        force_constant: 15.0
-        target: 15.0
+        force_constant: 15.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 calculation:
   windows:
     attach: 15
@@ -103,7 +103,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 2500
     model: "TIP3P"

--- a/taproom/systems/cb8/hxd/guest.yaml
+++ b/taproom/systems/cb8/hxd/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-hxd.pdb
 data_set:
   SAMPL: 6
   guest_id: G11
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/ket/guest.yaml
+++ b/taproom/systems/cb8/ket/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-ket.pdb
 data_set:
   SAMPL: 8
   guest_id: G5
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/mor/guest.yaml
+++ b/taproom/systems/cb8/mor/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-mor.pdb
 data_set:
   SAMPL: 8
   guest_id: G3
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/mpa/guest.yaml
+++ b/taproom/systems/cb8/mpa/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-mpa.pdb
 data_set:
   SAMPL: 6
   guest_id: G9
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/mth/guest.yaml
+++ b/taproom/systems/cb8/mth/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-mth.pdb
 data_set:
   SAMPL: 8
   guest_id: G1
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/oan/guest.yaml
+++ b/taproom/systems/cb8/oan/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-oan.pdb
 data_set:
   SAMPL: 6
   guest_id: G7
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/pal/guest.yaml
+++ b/taproom/systems/cb8/pal/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-pal.pdb
 data_set:
   SAMPL: 6
   guest_id: G2
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/pcp/guest.yaml
+++ b/taproom/systems/cb8/pcp/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-pcp.pdb
 data_set:
   SAMPL: 8
   guest_id: G6
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/qui/guest.yaml
+++ b/taproom/systems/cb8/qui/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-qui.pdb
 data_set:
   SAMPL: 6
   guest_id: G3
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/tbz/guest.yaml
+++ b/taproom/systems/cb8/tbz/guest.yaml
@@ -1,7 +1,7 @@
 name: tbz
 structure: tbz.mol2
 complex: cb8-tbz.pdb
-net_charge: +2
+net_charge: +2e
 data_set:
   SAMPL: 3
   guest_id: G8
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/tdz/guest.yaml
+++ b/taproom/systems/cb8/tdz/guest.yaml
@@ -1,7 +1,7 @@
 name: tdz
 structure: tdz.mol2
 complex: cb8-tdz.pdb
-net_charge: +2
+net_charge: +2e
 data_set:
   SAMPL: 3
   guest_id: G9
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/thp/guest.yaml
+++ b/taproom/systems/cb8/thp/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-thp.pdb
 data_set:
   SAMPL: 6
   guest_id: G5
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/cb8/trd/guest.yaml
+++ b/taproom/systems/cb8/trd/guest.yaml
@@ -4,7 +4,7 @@ complex: cb8-trd.pdb
 data_set:
   SAMPL: 6
   guest_id: G1
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,103 +16,104 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":CB8@C2 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C4 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C6 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C8 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C10 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C12 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C14 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C16 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C18 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C20 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C22 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C24 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C26 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C28 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C31 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":CB8@C32 G1"
-        force_constant: 50.0
-        target: 15.0
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/ben/guest.yaml
+++ b/taproom/systems/oah/ben/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-ben.pdb
 data_set:
   SAMPL: 4
   guest_id: O1
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/bra/guest.yaml
+++ b/taproom/systems/oah/bra/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-bra.pdb
 data_set:
   SAMPL: 5
   guest_id: O4
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/c3b/guest.yaml
+++ b/taproom/systems/oah/c3b/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-c3b.pdb
 data_set:
   SAMPL: 4
   guest_id: O5
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/c4b/guest.yaml
+++ b/taproom/systems/oah/c4b/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-c4b.pdb
 data_set:
   SAMPL: 4
   guest_id: O4
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/c5c/guest.yaml
+++ b/taproom/systems/oah/c5c/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-c5c.pdb
 data_set:
   SAMPL: 4
   guest_id: O8
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/c7c/guest.yaml
+++ b/taproom/systems/oah/c7c/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-c7c.pdb
 data_set:
   SAMPL: 4
   guest_id: O9
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/cbn/guest.yaml
+++ b/taproom/systems/oah/cbn/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-cbn.pdb
 data_set:
   SAMPL: 5
   guest_id: G2
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/chx/guest.yaml
+++ b/taproom/systems/oah/chx/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-chx.pdb
 data_set:
   SAMPL: 4
   guest_id: O6
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/cpa/guest.yaml
+++ b/taproom/systems/oah/cpa/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-cpa.pdb
 data_set:
   SAMPL: 6
   guest_id: G0
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/crl/guest.yaml
+++ b/taproom/systems/oah/crl/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-crl.pdb
 data_set:
   SAMPL: 6
   guest_id: G4
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/dpe/guest.yaml
+++ b/taproom/systems/oah/dpe/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-dpe.pdb
 data_set:
   SAMPL: 6
   guest_id: G7
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/ebn/guest.yaml
+++ b/taproom/systems/oah/ebn/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-ebn.pdb
 data_set:
   SAMPL: 4
   guest_id: O3
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/host-p.yaml
+++ b/taproom/systems/oah/host-p.yaml
@@ -1,7 +1,7 @@
 name: oah
 structure: oah.mol2
 resname: OAH
-net_charge: -8.0
+net_charge: -8.0e
 aliases:
   - D1: ":DM1"
   - D2: ":DM2"
@@ -13,71 +13,71 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":OAH@O13 :OAH@O18"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@O14 :OAH@O17"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@O15 :OAH@O16"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@O19 :OAH@O20"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C49 :OAH@C62"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C50 :OAH@C61"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C55 :OAH@C68"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C56 :OAH@C67"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C69 :OAH@C91"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C74 :OAH@C96"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C75 :OAH@C81"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAH@C79 :OAH@C85"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 calculation:
   windows:
@@ -88,7 +88,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 3000
     model: "TIP3P"

--- a/taproom/systems/oah/hx5/guest.yaml
+++ b/taproom/systems/oah/hx5/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-hx5.pdb
 data_set:
   SAMPL: 6
   guest_id: G3
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/hxa/guest.yaml
+++ b/taproom/systems/oah/hxa/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-hxa.pdb
 data_set:
   SAMPL: 5
   guest_id: G3
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/hxy/guest.yaml
+++ b/taproom/systems/oah/hxy/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-hxy.pdb
 data_set:
   SAMPL: 5
   guest_id: G1
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/m4p/guest.yaml
+++ b/taproom/systems/oah/m4p/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-m4p.pdb
 data_set:
   SAMPL: 6
   guest_id: G5
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/mbn/guest.yaml
+++ b/taproom/systems/oah/mbn/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-mbn.pdb
 data_set:
   SAMPL: 4
   guest_id: O2
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/mhc/guest.yaml
+++ b/taproom/systems/oah/mhc/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-mhc.pdb
 data_set:
   SAMPL: 4
   guest_id: O7
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/mpe/guest.yaml
+++ b/taproom/systems/oah/mpe/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-mpe.pdb
 data_set:
   SAMPL: 6
   guest_id: G6
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/nbn/guest.yaml
+++ b/taproom/systems/oah/nbn/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-nbn.pdb
 data_set:
   SAMPL: 5
   guest_id: G6
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/prl/guest.yaml
+++ b/taproom/systems/oah/prl/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-prl.pdb
 data_set:
   SAMPL: 6
   guest_id: G2
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/t2h/guest.yaml
+++ b/taproom/systems/oah/t2h/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-t2h.pdb
 data_set:
   SAMPL: 6
   guest_id: G1
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oah/trz/guest.yaml
+++ b/taproom/systems/oah/trz/guest.yaml
@@ -4,7 +4,7 @@ complex: oah-trz.pdb
 data_set:
   SAMPL: 5
   guest_id: G5
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAH@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAH@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/bra/guest.yaml
+++ b/taproom/systems/oam/bra/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-bra.pdb
 data_set:
   SAMPL: 5
   guest_id: O4
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/cbn/guest.yaml
+++ b/taproom/systems/oam/cbn/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-cbn.pdb
 data_set:
   SAMPL: 5
   guest_id: G2
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/cpa/guest.yaml
+++ b/taproom/systems/oam/cpa/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-cpa.pdb
 data_set:
   SAMPL: 6
   guest_id: G0
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/crl/guest.yaml
+++ b/taproom/systems/oam/crl/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-crl.pdb
 data_set:
   SAMPL: 6
   guest_id: G4
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/dpe/guest.yaml
+++ b/taproom/systems/oam/dpe/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-dpe.pdb
 data_set:
   SAMPL: 6
   guest_id: G7
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/host-p.yaml
+++ b/taproom/systems/oam/host-p.yaml
@@ -1,7 +1,7 @@
 name: oam
 structure: oam.mol2
 resname: OAM
-net_charge: -8.0
+net_charge: -8.0e
 aliases:
   - D1: ":DM1"
   - D2: ":DM2"
@@ -13,71 +13,71 @@ restraints:
   static:
     - restraint:
         atoms: D1 H1
-        force_constant: 5.0
+        force_constant: 5.0 * kilocalorie / mole / angstrom**2
     - restraint:
         atoms: D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D3 D2 D1 H1
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D2 D1 H1 H2
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
     - restraint:
         atoms: D1 H1 H2 H3
-        force_constant: 100.0
+        force_constant: 100.0 * kilocalorie / mole / radian**2
   conformational:
     - restraint:
         atoms: ":OAM@O13 :OAM@O18"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@O14 :OAM@O17"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@O15 :OAM@O16"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@O19 :OAM@O20"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C49 :OAM@C62"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C50 :OAM@C61"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C55 :OAM@C68"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C56 :OAM@C67"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C69 :OAM@C91"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C74 :OAM@C96"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C75 :OAM@C81"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
     - restraint:
         atoms: ":OAM@C79 :OAM@C85"
-        force_constant: 25.0
-        target: 15.0
+        force_constant: 25.0 * kilocalorie / mole / angstrom**2
+        target: 15.0 * angstrom
 
 calculation:
   windows:
@@ -88,7 +88,7 @@ calculation:
     attach: [0.0, 0.004, 0.008, 0.016, 0.024, 0.04, 0.055, 0.0865, 0.118, 0.181, 0.244, 0.37, 0.496, 0.748, 1.0]
     release: [1.0, 0.748, 0.496, 0.37, 0.244, 0.181, 0.118, 0.0865, 0.055, 0.04, 0.024, 0.016, 0.008, 0.004, 0.0]
   target:
-    pull: 24.0
+    pull: 24.0 * angstrom
   system:
     waters: 3000
     model: "TIP3P"

--- a/taproom/systems/oam/hx5/guest.yaml
+++ b/taproom/systems/oam/hx5/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-hx5.pdb
 data_set:
   SAMPL: 6
   guest_id: G3
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/hxa/guest.yaml
+++ b/taproom/systems/oam/hxa/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-hxa.pdb
 data_set:
   SAMPL: 5
   guest_id: G3
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/hxy/guest.yaml
+++ b/taproom/systems/oam/hxy/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-hxy.pdb
 data_set:
   SAMPL: 5
   guest_id: G1
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/m4p/guest.yaml
+++ b/taproom/systems/oam/m4p/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-m4p.pdb
 data_set:
   SAMPL: 6
   guest_id: G5
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/mpe/guest.yaml
+++ b/taproom/systems/oam/mpe/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-mpe.pdb
 data_set:
   SAMPL: 6
   guest_id: G6
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/nbn/guest.yaml
+++ b/taproom/systems/oam/nbn/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-nbn.pdb
 data_set:
   SAMPL: 5
   guest_id: G6
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/prl/guest.yaml
+++ b/taproom/systems/oam/prl/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-prl.pdb
 data_set:
   SAMPL: 6
   guest_id: G2
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/t2h/guest.yaml
+++ b/taproom/systems/oam/t2h/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-t2h.pdb
 data_set:
   SAMPL: 6
   guest_id: G1
-net_charge: -1
+net_charge: -1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.

--- a/taproom/systems/oam/trz/guest.yaml
+++ b/taproom/systems/oam/trz/guest.yaml
@@ -4,7 +4,7 @@ complex: oam-trz.pdb
 data_set:
   SAMPL: 5
   guest_id: G5
-net_charge: +1
+net_charge: +1e
 aliases:
     - D1: :DM1
     - D2: :DM2
@@ -16,55 +16,56 @@ restraints:
     - restraint:
         atoms: D1 G1
         attach:
-          # During the attach phase, the `force_constant` argument is the
+          # During the 'attach' phase, the `force_constant` argument is the
           # final force constant.
-          force_constant: 5.0
-          target: 6.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 6.0 * angstrom
         pull:
-          # During the pull phase, the `target` argument is the final value of
+          # During the 'pull' phase, the `target` argument is the final value of
           # the restraint.
-          force_constant: 5.0
-          target: 24.0
+          force_constant: 5.0 * kilocalorie / mole / angstrom**2
+          target: 24.0 * angstrom
     - restraint:
         atoms: D2 D1 G1
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
     - restraint:
         atoms: D1 G1 G2
         attach:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
         pull:
-          force_constant: 100.0
-          target: 180.0
+          force_constant: 100.0 * kilocalorie / mole / radian**2
+          target: 180.0 * degrees
 
   wall_restraints:
     - restraint:
         atoms: ":OAM@C45 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C51 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C57 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
     - restraint:
         atoms: ":OAM@C63 G1"
-        force_constant: 50.0
-        target: 13.5
+        force_constant: 50.0 * kilocalorie / mole / angstrom**2
+        target: 13.5 * angstrom
 
 symmetry_correction:
   restraints:
-      - restraint:
+    - restraint:
         atoms: D2 G1 G2
-        force_constant: 200.0
+        force_constant: 200.0 * kilocalorie / mole / radian**2
+        target: 91 * degrees
   # Do not attempt to automatically correct for the symmetry restraint by adding -RT \ln (microstates).
   # Instead, we will apply the symmetry restraint, which locks in a particular binding orientation, and then
   # perform separate calculations.


### PR DESCRIPTION
This PR adds openff-units to `force_constant` and `target` values for each `host-*.yaml` and `guest.yaml` files. An updated `read_yaml.py` module in pAPRika will convert the string to a `unit.Quantity` object. This should resolve https://github.com/slochower/host-guest-benchmarks/issues/3